### PR TITLE
#19 - JPa Buddy Plugin gitIgnore 에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 ### Querydsl
 /src/main/generated
 
-
+### JPA BUDDY
+.jpb/
 
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider


### PR DESCRIPTION
InteliJ 에서 제공해주는 JPA Buddy를 gitIgnore.io 에 추가 
및
 중간 푸시